### PR TITLE
Fixes >>> handling

### DIFF
--- a/py/utils.py
+++ b/py/utils.py
@@ -73,7 +73,8 @@ def parse_posts(list,post_replies=None):
         #If someone has been lazy, lets fix
         for untagged_url in fixlist:
             fixed_url = re.sub(re.compile(uri, re.MULTILINE),r'<a href="\1">\1</a>',str(untagged_url))
-            com = com.replace(untagged_url, fixed_url)
+            if "boards.4chan" not in untagged_url:
+                com = com.replace(untagged_url, fixed_url)
 
         #Make greentext green
         com = re.sub(r'\<span class=\"quote\"\>\>(.*?)\<\/span\>', r'<font color="#32CD32">>\1</font>',com)


### PR DESCRIPTION
Fixes #27 though it could lead to untagging links to other websites if they contain 'boards.4chan' somewhere in the uri and are not actual links to 4chan boards, for 4chan intralinks seems to work fine, so in theory should cover 99% cases (it's mostly for bare links to boards like >>>/pol/ or >>>/bant, if there is a thread number provided the app already correctly translates them as direct links it seems)