### PR TITLE
Fix for multiple pinned threads replies count

### DIFF
--- a/qml/pages/ThreadsPage.qml
+++ b/qml/pages/ThreadsPage.qml
@@ -365,9 +365,8 @@ AbstractPage {
                     var updateItem
                     updateItem = pinModel.get(i)
 
-                  //  for (var j=0; j<result.length; j++) {
-                        updateItem.postCount = result[i]['postCount']
-                  //  }
+                    updateItem.postCount = result[i]['postCount']
+
                 }
             });
 

--- a/qml/pages/ThreadsPage.qml
+++ b/qml/pages/ThreadsPage.qml
@@ -365,9 +365,9 @@ AbstractPage {
                     var updateItem
                     updateItem = pinModel.get(i)
 
-                    for (var j=0; j<result.length; j++) {
-                        updateItem.postCount = result[j]['postCount']
-                    }
+                  //  for (var j=0; j<result.length; j++) {
+                        updateItem.postCount = result[i]['postCount']
+                  //  }
                 }
             });
 


### PR DESCRIPTION
Looks like that inside loop wasn't needed, or at least after this change the replies count in pinned threads view now updates per thread
Fixes #24 