### PR TITLE
Should fix replies stuck at 1 in pinned thread

### DIFF
--- a/py/posts.py
+++ b/py/posts.py
@@ -43,7 +43,7 @@ def get_posts(board_id,postno):
             post_values['no'] = post.post_id
 
             if post.post_id == postno :
-                post_values['replies'] = len(thread.posts)
+                post_values['replies'] = len(thread.posts)-1
                 post_values['sticky'] = int(thread.sticky)
             else:
                 post_values['replies'] = 0
@@ -93,7 +93,7 @@ def get_new_posts_count(board_id,postno,replies_count):
     if thread is None:
         return None
     else:
-        updated_replies_count = len(thread.posts)
+        updated_replies_count = len(thread.posts)-1
 
         total = updated_replies_count - replies_count
 


### PR DESCRIPTION
PostsPage.qml has 
var replies_count = postsModel.count-1 
which I believe was the cause for the 1 returning, as it would re-update the pinned db with lower value