### PR TITLE
Static height for the new post textarea

### DIFF
--- a/qml/items/DockedNewPost.qml
+++ b/qml/items/DockedNewPost.qml
@@ -108,6 +108,7 @@ DockedPanel {
                         id: commentText
                         enabled: !busy
                         width: parent.width
+                        height: 400
                         font.family: Theme.fontFamily
                         font.pixelSize: Theme.fontSizeSmall
                         clip: false


### PR DESCRIPTION
This fixes #43 but not sure if hardcoding 400 is the right way to do it, maybe screenheight/3 or something would be more robust, works on jolla C fine with the panel being wholly visible while editing and allows to scroll through the textarea so one can reach quoted text or go back to edit previous parts of comment without closing the dockedpanel