### PR TITLE
WebView option added to PostsPage

### DIFF
--- a/qml/pages/PostsPage.qml
+++ b/qml/pages/PostsPage.qml
@@ -125,6 +125,13 @@ AbstractPage {
                         Qt.openUrlExternally(url)
                     }
                 }
+                MenuItem {
+                    text: qsTr("Open thread in webview")
+                    onClicked: {
+                        var url = "https://boards.4chan.org/"+boardId+"/thread/"+postNo
+                        onClicked: pageStack.push("WebViewPage.qml", {"pageurl": url });
+                    }
+                }
 
                 MenuItem {
                     text: "Add pin"

--- a/qml/pages/WebViewPage.qml
+++ b/qml/pages/WebViewPage.qml
@@ -1,0 +1,20 @@
+import QtQuick 2.2
+import Sailfish.Silica 1.0
+
+ Page {
+    property string pageurl
+    allowedOrientations: Orientation.All
+     SilicaWebView {
+         id: webView
+
+         anchors {
+             top: parent.top
+             left: parent.left
+             right: parent.right
+             bottom: parent.bottom
+         }
+         url: pageurl
+     }
+
+ }
+


### PR DESCRIPTION
A basic webview page to allow quick checking of a thread in case of parsing issues (the long outstanding <> handling in comments, or checking flags etc), faster than opening external browser and also avoids the bug with external browser launcher introduced in 3.1.0