### PR TITLE
Scrolloption to last loaded position

### DIFF
--- a/qml/items/PostItem.qml
+++ b/qml/items/PostItem.qml
@@ -408,7 +408,7 @@ BackgroundItem {
     onClicked: {
         switch(mode){
         case "pinned":
-            pageStack.push(Qt.resolvedUrl("../pages/PostsPage.qml"), {postNo: no, boardId: post_board, pinned: true } )
+            pageStack.push(Qt.resolvedUrl("../pages/PostsPage.qml"), {postNo: no, boardId: post_board, pinned: true, repscount: postCount } )
             break;
         case "thread":
             if(pin) {

--- a/qml/pages/PostsPage.qml
+++ b/qml/pages/PostsPage.qml
@@ -31,6 +31,7 @@ AbstractPage {
     property int totalPosts: 0
     property var modelToStrip;
     property bool pinned;
+    property int repscount;
     property int replyTo: postNo
     property int reloadTime: {
         switch( SettingsStore.getSetting("ThreadRefreshTime") ) {
@@ -133,7 +134,15 @@ AbstractPage {
                         pyp.pin(postNo,boardId)
                     }
                 }
-
+                
+                MenuItem {
+                    text: "Scroll to last loaded"
+                    visible: pinned && repscount !== 0
+                    onClicked: {
+                        listView.positionViewAtIndex(postsModel.count - repscount, ListView.Beginning);
+                    }
+                }
+                
                 MenuItem {
                     text: "Remove pin"
                     visible: pinned && pageStack.depth === 2


### PR DESCRIPTION
Added option to scroll to last known position (based on the replies count the pinned thread was last updated with), only shows up if in pinned mode and there are more posts than at the last update