### PR TITLE
Removes the ugly indent on long posts with image

### DIFF
--- a/qml/items/PostItem.qml
+++ b/qml/items/PostItem.qml
@@ -262,10 +262,10 @@ BackgroundItem {
                         }
                     }
                 }
-
+}
                 Item {
                     id: commentArea
-
+                    anchors.fill: parent
                     width: has_file ? parent.width-thumbNailArea.width : parent.width;
                     height: mode === "post" ? postText.contentHeight :  contentAreaHeight;
 
@@ -286,7 +286,12 @@ BackgroundItem {
                         onLinkActivated: {
                             Utils.openLink(link)
                         }
-
+                        onLineLaidOut: {
+                            if (line.y < thumbNailArea.height && has_file) {
+                                line.x = line.x + thumbNailArea.width +5
+                                line.width = line.width - (thumbNailArea.width + 5)
+                            }
+                        }
                         Image {
                             id: dots
                             height: 32
@@ -306,7 +311,7 @@ BackgroundItem {
                         }
                     }
                 }
-            }
+            
         }
 
         Item {


### PR DESCRIPTION
Tested in sdk with different resolutions (jolla c, xperia and tablet) and seems to be wrapping around the thumbnail correctly, even if it leaves a bit too much space on the tablet form from the bottom of thumbnail if we're nitpicky