### PR TITLE
Yandex Image Search option

### DIFF
--- a/qml/pages/ImageViewPage.qml
+++ b/qml/pages/ImageViewPage.qml
@@ -122,6 +122,14 @@ AbstractPage {
             id: imageViewMenu
 
             MenuItem {
+                text: qsTr("Yandex Image Search")
+                onClicked: {
+                    infoBanner.alert("Launching external web browser...");
+                    Qt.openUrlExternally('https://yandex.com/images/search?rpt=imageview&url=' + imgUrl)
+                }
+            }
+            
+            MenuItem {
                 text: qsTr("Open in browser")
                 onClicked: {
                     infoBanner.alert("Launching external web browser...");


### PR DESCRIPTION
Google goes out of its way to prevent mobile users from searching images based on URLs, Yandex works great in sailfish browser and seems to give even better results from my limited testing (more pages where image is included, more resolution options, even works reliably with crops as google used to ages ago), only issue is the summary is in russian, but that seems minor