### PR TITLE
Initialize settings with ModelToDisplayOnNavipage=Allboards

### DIFF
--- a/qml/js/settingsStorage.js
+++ b/qml/js/settingsStorage.js
@@ -29,7 +29,10 @@ function initialize() {
         function(tx) {
             // Create the settings table if it doesn't already exist
             // If the table exists, this is skipped
-            tx.executeSql('CREATE TABLE IF NOT EXISTS settings(setting TEXT UNIQUE, value TEXT)');
+            console.log("run initialize")
+            tx.executeSql('CREATE TABLE IF NOT EXISTS settings(setting TEXT UNIQUE, value TEXT);');
+            // Set default Board view to "All boards"
+            tx.executeSql('INSERT OR IGNORE INTO settings VALUES ("ModelToDisplayOnNavipage",0);');
     });
 }
 
@@ -60,21 +63,27 @@ function setSetting(setting, value) {
 // Retrieve a setting from the database
 function getSetting(setting, defaultValue) {
     var db = getDatabase();
-    var res="";
+    var res = "";
 
-    db.transaction(function(tx) {
-        var rs = tx.executeSql('SELECT value FROM settings WHERE setting=?;', [setting]);
-
-        if (rs.rows.length > 0) {
-            res = rs.rows.item(0).value;
-        }
-        else {
-            res = defaultValue || "Unknown";
-        }
-  })
+    try {
+        db.transaction(function(tx) {
+            var rs = tx.executeSql('SELECT value FROM settings WHERE setting=?;', [setting]);
+    
+            if (rs.rows.length > 0) {
+                res = rs.rows.item(0).value;
+            }
+            else {
+                res = defaultValue || "Unknown";
+            }
+      });
+    } catch(error) {
+        res = "error";
+    }
 
   // We return “Unknown” if the setting was not found in the database
   // Handling error codes should be implemented in the future
+  console.log(res)
+    console.log(typeof(res))
   return res
 }
 

--- a/qml/js/settingsStorage.js
+++ b/qml/js/settingsStorage.js
@@ -29,7 +29,6 @@ function initialize() {
         function(tx) {
             // Create the settings table if it doesn't already exist
             // If the table exists, this is skipped
-            console.log("run initialize")
             tx.executeSql('CREATE TABLE IF NOT EXISTS settings(setting TEXT UNIQUE, value TEXT);');
             // Set default Board view to "All boards"
             tx.executeSql('INSERT OR IGNORE INTO settings VALUES ("ModelToDisplayOnNavipage",0);');
@@ -82,8 +81,6 @@ function getSetting(setting, defaultValue) {
 
   // We return “Unknown” if the setting was not found in the database
   // Handling error codes should be implemented in the future
-  console.log(res)
-    console.log(typeof(res))
   return res
 }
 

--- a/qml/js/settingsStorage.js
+++ b/qml/js/settingsStorage.js
@@ -93,4 +93,6 @@ function resetSettingsDB() {
             // Used for clearing user settings and testing reasons
             tx.executeSql('DROP TABLE IF EXISTS settings');
     });
+    // Reset default board view
+    initialize()
 }

--- a/qml/pages/NaviPage.qml
+++ b/qml/pages/NaviPage.qml
@@ -7,7 +7,7 @@ import "../js/settingsStorage.js" as SettingsStore
 
 AbstractPage {
     id: naviPage
-    property variant show_model: SettingsStore.getSetting("ModelToDisplayOnNavipage", "0") !== "0" ? favoriteModel : boardModel
+    property variant show_model: SettingsStore.getSetting("ModelToDisplayOnNavipage") !== "1" ?  boardModel : favoriteModel 
     property bool show_pinned_model: true
     property variant pinModel: ListModel {id: pinModel }
 

--- a/qml/pages/NaviPage.qml
+++ b/qml/pages/NaviPage.qml
@@ -7,7 +7,7 @@ import "../js/settingsStorage.js" as SettingsStore
 
 AbstractPage {
     id: naviPage
-    property variant show_model: SettingsStore.getSetting("ModelToDisplayOnNavipage", 0) == 0 ? boardModel : favoriteModel
+    property variant show_model: SettingsStore.getSetting("ModelToDisplayOnNavipage", "0") !== "0" ? favoriteModel : boardModel
     property bool show_pinned_model: true
     property variant pinModel: ListModel {id: pinModel }
 


### PR DESCRIPTION
When settings table is first created, set ModelToDisplayOnNavipage to "0" (string). Hopefully avoids situation where first time user only sees blank page on board navigation https://openrepos.net/comment/37567#comment-37567