### PR TITLE
Highlight posts by ID

### DIFF
--- a/py/posts.py
+++ b/py/posts.py
@@ -50,6 +50,7 @@ def get_posts(board_id,postno):
 
             post_values['closed'] = int(thread.closed)
             post_values['poster_id'] = post.poster_id
+            post_values['highlight_post'] = 0            
             post_values['country_name'] = post.country_name
             post_values['countrycode'] = post.countrycode
             post_values['board_flag'] = post.board_flag

--- a/qml/items/PostItem.qml
+++ b/qml/items/PostItem.qml
@@ -28,6 +28,20 @@ GridItem {
             }
         }
     }
+    Item {
+        anchors.fill: parent
+
+        Rectangle {
+            visible: highlight_post
+            width: parent.width
+            height: post.height
+
+            gradient: Gradient {
+                GradientStop { position: 0.0; color: Theme.rgba(Theme.primaryColor, 0.2) }
+                GradientStop { position: 1.0; color: Theme.rgba(Theme.primaryColor, 0.4) }
+            }
+        }
+    }
 
     Column {
         id: post
@@ -487,7 +501,7 @@ GridItem {
             if (pP)
                 var modelToStrip = pP.returnModel()
 
-            contextMenu = contextMenuComponent.createObject(listView, {postReplies: postReplies, thisPostNo: no, modelToStrip : modelToStrip,com: com})
+            contextMenu = contextMenuComponent.createObject(listView, {postReplies: postReplies, thisPostNo: no, modelToStrip : modelToStrip,com: com, poster_id: poster_id})
             contextMenu.open(delegate)
             break;
 

--- a/qml/pages/PostsPage.qml
+++ b/qml/pages/PostsPage.qml
@@ -33,6 +33,7 @@ AbstractPage {
     property string board_flag;
     property var postsToShow;
     property int totalPosts: 0
+    property bool highlight_post: false
     property int pageCount;
     property var modelToStrip;
     property bool pinned;
@@ -51,6 +52,15 @@ AbstractPage {
         }
     }
 
+    function highbyid(filter){
+        for (var j=0; j < postsModel.count; j++){
+            if (postsModel.get(j).poster_id.indexOf(filter) >= 0){
+                postsModel.setProperty(j, "highlight_post", 1)
+            } else postsModel.setProperty(j, "highlight_post", 0)
+        }
+
+    }
+    
     function getBackToPost() {
         pageStack.pop(pageStack.find( function(page){ return(page.pageCount !== 1)} ), PageStackAction.Immediate)
     }
@@ -232,6 +242,7 @@ AbstractPage {
                 id: contextMenuComponent
 
                 ContextMenu {
+                    property string poster_id
                     property string postReplies
                     property string com
                     property var quote
@@ -265,6 +276,16 @@ AbstractPage {
                         }
                     }
 
+                    MenuItem {
+                        visible: poster_id && pageStack.depth === 2
+                        text: qsTr("Highlight posts by ID")
+                        onClicked: {
+
+                            highbyid(poster_id)
+
+                        }
+                    }
+                    
                     MenuItem {
                         text: qsTr("Quote")
                         onClicked: {


### PR DESCRIPTION
This mimics clicking on an ID on supported boards and avoids messing with models too much (search probably will have to do that anyways, but the highlight does its job and allows to keep track of OP posts etc)