### PR TITLE
Qml captcha prototype

### DIFF
--- a/py/posting.py
+++ b/py/posting.py
@@ -22,7 +22,7 @@ bp = None
 
 user_agent = 'Mozilla/5.0 (X11; Linux x86_64; rv:58.0) Gecko/20100101 Firefox/58.0'
 
-def post(nickname="", comment="", subject="", file_attach="", captcha_response="", board="",threadno=""):
+def post(nickname="", comment="", subject="", file_attach="", captcha_response="", board="", challenge="",threadno=""):
     '''
     file_attach: (/path/to/file.ext) will be uploaded as "file" + extension
     '''
@@ -65,7 +65,8 @@ def post(nickname="", comment="", subject="", file_attach="", captcha_response="
                     'resto' : (None, str(threadno)),
                     # 'email' : ('', ''),
                     'com' : (None, str(comment)),
-                    'g-recaptcha-response' : (None, captcha_response),
+                    't-response' : (None, str(captcha_response)),
+                    't-challenge' : (None, str(challenge)),
                     'upfile' : (filename, filedata, content_type)
                 }
         

--- a/qml/items/DockedNewPost.qml
+++ b/qml/items/DockedNewPost.qml
@@ -234,11 +234,11 @@ DockedPanel {
                         }
 
                         newPostItem.replyTo
-                            ? pageStack.push("../pages/Captcha2Page.qml",
+                            ? pageStack.push("../pages/CaptchaPage.qml",
                               {
-                                  "replyTo" : newPostItem.replyTo
+                                  "replyTo" : newPostItem.replyTo, "boardId": postsPage.boardId, "comment": comment
                               })
-                            : pageStack.push("../pages/Captcha2Page.qml");
+                            : pageStack.push("../pages/CaptchaPage.qml");
                     }
                 }
 

--- a/qml/items/DockedNewPost.qml
+++ b/qml/items/DockedNewPost.qml
@@ -236,9 +236,9 @@ DockedPanel {
                         newPostItem.replyTo
                             ? pageStack.push("../pages/CaptchaPage.qml",
                               {
-                                  "replyTo" : newPostItem.replyTo, "boardId": postsPage.boardId, "comment": comment
+                                  "replyTo" : newPostItem.replyTo, "boardId": postsPage.boardId, "comment": comment, "nickname": nickname, "subject": subject, "selectedFile": selectedFile
                               })
-                            : pageStack.push("../pages/CaptchaPage.qml");
+                            : pageStack.push("../pages/CaptchaPage.qml", {"boardId": threadPage.boardId, "comment": comment, "nickname": nickname, "subject": subject, "selectedFile": selectedFile});
                     }
                 }
 

--- a/qml/items/DockedNewPost.qml
+++ b/qml/items/DockedNewPost.qml
@@ -236,7 +236,7 @@ DockedPanel {
                         newPostItem.replyTo
                             ? pageStack.push("../pages/CaptchaPage.qml",
                               {
-                                  "replyTo" : newPostItem.replyTo, "boardId": postsPage.boardId, "comment": comment, "nickname": nickname, "subject": subject, "selectedFile": selectedFile
+                                  "replyTo" : threadId, "boardId": postsPage.boardId, "comment": comment, "nickname": nickname, "subject": subject, "selectedFile": selectedFile
                               })
                             : pageStack.push("../pages/CaptchaPage.qml", {"boardId": threadPage.boardId, "comment": comment, "nickname": nickname, "subject": subject, "selectedFile": selectedFile});
                     }

--- a/qml/items/PostItem.qml
+++ b/qml/items/PostItem.qml
@@ -433,7 +433,7 @@ GridItem {
                 pageStack.push(Qt.resolvedUrl("../pages/PostsPage.qml"), {postNo: no, boardId: post_board, pinned: true } )
             }
             else {
-                pageStack.push(Qt.resolvedUrl("../pages/PostsPage.qml"), {postNo: no, boardId: post_board, pinned: false} )
+                pageStack.push(Qt.resolvedUrl("../pages/PostsPage.qml"), {postNo: no, threadId: threadId, boardId: post_board, pinned: false} )
             }
             break;
 
@@ -456,7 +456,8 @@ GridItem {
                                        postNo: thisPostNo,
                                        boardId: boardId,
                                        modelToStrip : modelToStrip,
-                                       postsToShow : postsToShow
+                                       postsToShow : postsToShow,
+                                       threadId: threadId
                                    } )
                 }
                 else {
@@ -464,7 +465,8 @@ GridItem {
                                        postNo: thisPostNo,
                                        boardId: boardId,
                                        modelToStrip : postsModel,
-                                       postsToShow : postsToShow
+                                       postsToShow : postsToShow,
+                                       threadId: threadId
                                    } )
                 }
             }

--- a/qml/items/PostItemThread.qml
+++ b/qml/items/PostItemThread.qml
@@ -406,14 +406,14 @@ GridItem {
     onClicked: {
         switch(mode){
         case "pinned":
-            pageStack.push(Qt.resolvedUrl("../pages/PostsPage.qml"), {postNo: no, boardId: post_board, pinned: true, repscount: postCount } )
+            pageStack.push(Qt.resolvedUrl("../pages/PostsPage.qml"), {postNo: no, threadId: no, boardId: post_board, pinned: true, repscount: postCount } )
             break;
         case "thread":
             if(pin) {
-                pageStack.push(Qt.resolvedUrl("../pages/PostsPage.qml"), {postNo: no, boardId: post_board, pinned: true } )
+                pageStack.push(Qt.resolvedUrl("../pages/PostsPage.qml"), {postNo: no, threadId: no, boardId: post_board, pinned: true } )
             }
             else {
-                pageStack.push(Qt.resolvedUrl("../pages/PostsPage.qml"), {postNo: no, boardId: post_board, pinned: false} )
+                pageStack.push(Qt.resolvedUrl("../pages/PostsPage.qml"), {postNo: no, threadId: no, boardId: post_board, pinned: false} )
             }
             break;
 

--- a/qml/js/utils.js
+++ b/qml/js/utils.js
@@ -120,6 +120,7 @@ function openLink(link) {
         pageStack.push(Qt.resolvedUrl("../pages/PostsPage.qml"), {
                            postNo: postNo,
                            boardId: boardId,
+                           threadId: threadId,
                            modelToStrip: model,
                            postsToShow:postsToShow,
                            singlePostNo: singlePostNo

--- a/qml/pages/CaptchaPage.qml
+++ b/qml/pages/CaptchaPage.qml
@@ -54,11 +54,7 @@ import io.thp.pyotherside 1.4
                 title: "Captcha"
                 }
                 
-        Item{
-            y: screen.height/2 - page.img_height /2
 
-                width: page.img_width *2 
-                height: page.img_height *2
             Image {
                 id: imgfg
                 anchors.top: header.bottom
@@ -76,14 +72,28 @@ import io.thp.pyotherside 1.4
             }
             Rectangle {
                 anchors.left: imgbg.right
+                anchors.top: header.bottom
                 height: page.img_height *2
                 width: screen.width - page.img_width *2 
                 color: Theme.rgba(Theme.primaryColor, 1)
             }
-              TextField {
+        
+            Slider {
+                id: bgslider
+                anchors.top: imgbg.bottom
+                minimumValue: 0
+                maximumValue: 200
+                stepSize: 2
+                enabled: true
+                width: parent.width
+                handleVisible: true
+                label: qsTr("Slide to reveal captcha")
+            }
+            
+            TextField {
                 id: captchaInput
                 width: parent.width
-                anchors.top: imgbg.bottom
+                anchors.top: bgslider.bottom
                 placeholderText: "Enter CAPTCHA"                          
                 EnterKey.enabled: text.length > 2
                 EnterKey.iconSource: "image://theme/icon-m-enter-accept"
@@ -91,30 +101,12 @@ import io.thp.pyotherside 1.4
                    replyTo ? py.postpost(text) : py.postthread(text);
                         pageStack.navigateBack();
                     }
-                    
 
             }
-        
-
-
-        
-            Slider {
-            id: bgslider
-            anchors.top: captchaInput.bottom
-            minimumValue: 0
-            maximumValue: 200
-            stepSize: 2
-            enabled: true
-            width: parent.width
-            handleVisible: true
-            label: qsTr("Slide to reveal captcha")
-            
-        
-        }
     Component.onCompleted: {
             page.getCaptcha();
-        }
-        }
+        
+    }
 }
                 Python {
         id: py

--- a/qml/pages/CaptchaPage.qml
+++ b/qml/pages/CaptchaPage.qml
@@ -3,17 +3,14 @@ import Sailfish.Silica 1.0
 import "../items"
 import io.thp.pyotherside 1.4
 
-//ApplicationWindow{
 
-    
-//initialPage: Page {
         Page {
-    id: page
+        id: page
         property string imgdata: ""
         property string bgdata: ""
-            property string nickname
-            property string subject 
-            property string selectedFile
+        property string nickname
+        property string subject 
+        property string selectedFile
         property string challenge
         property string replyTo
         property string boardId
@@ -24,81 +21,62 @@ import io.thp.pyotherside 1.4
         property int bg_width
         property int img_height
         property bool loaded: false
-                       function getCaptcha(){
+        
+        
+        function getCaptcha(){
             var xhr = new XMLHttpRequest;
-        xhr.open("GET",  url);//"https://sys.4channel.org/captcha?board=" + boardId + "&thread_id=" + replyTo);// + thread_id);
-        xhr.onreadystatechange = function() {
+            xhr.open("GET",  url);
+            xhr.onreadystatechange = function() {
             if (xhr.readyState === XMLHttpRequest.DONE) {
-                    console.log(boardId, replyTo, url);
+
                 var data = JSON.parse(xhr.responseText);
-                    loaded = true;
+                loaded = true;
                 challenge = data.challenge;
                 imgdata  = data.img;
                 img_width = data.img_width;
                 img_height = data.img_height;
                 bgdata = data.bg;
                 bg_width = data.bg_width;
-                    console.log(challenge, img_width, bg_width);                
+             
             }
                                 
         }
             xhr.send();
 
-            console.log("end", page.imgdata,page.loaded);
         }
 
-        function postCaptcha(text){
-            var xhr = new XMLHttpRequest;
-            var url = "https://sys.4channel.org/" + boardId + "/post";
-            var params = encodeURI("MAX_FILE_SIZE=4194304&mode=regist&resto=" + replyTo + "&name=&email=&com=" + comment + "&t-response=" + text + "&t-challenge=" + challenge);
-            console.log(params, url);
-        xhr.open("POST",  url, true);
-            xhr.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
- 
-            xhr.setRequestHeader("Content-length", params.length);
-            xhr.setRequestHeader("Connection", "close");
-            xhr.onreadystatechange = function() {
-            if (xhr.readyState === XMLHttpRequest.DONE) {
-                    console.log(xhr.responseText);
-                }
-            }
-            xhr.send(params);    
-        }
         
         Item{
             y: screen.height/2 - page.img_height /2
-           // x: screen.width/2
+
                 width: page.img_width *2 
                 height: page.img_height *2
-    Image {
+            Image {
                 id: imgfg
                 anchors.top: parent.top
                 width: page.bg_width *2 
                 height: page.img_height *2
-                x: 100 - bgslider.value
-                
-                    
-            
-        source: !page.loaded ? page.imgdata : "data:image/png;base64," + page.bgdata  
+                x: 100 - bgslider.value    
+                source: !page.loaded ? page.imgdata : "data:image/png;base64," + page.bgdata  
             }
             Image {
                 id: imgbg
                 anchors.top: parent.top
                 width: page.img_width *2 
                 height: page.img_height *2
-        source: !page.loaded ? page.bgdata : "data:image/png;base64," + page.imgdata  
+                source: !page.loaded ? page.bgdata : "data:image/png;base64," + page.imgdata  
             }
             Rectangle {
                 anchors.left: imgbg.right
                 height: page.img_height *2
                 width: screen.width - page.img_width *2 
-        color: Theme.rgba(Theme.primaryColor, 1)
+                color: Theme.rgba(Theme.primaryColor, 1)
             }
-                        SearchField {
-                id: searchField
+              TextField {
+                id: captchaInput
                 width: parent.width
                 anchors.bottom: imgbg.top
-                 placeholderText: "Enter CAPTCHA"                          
+                placeholderText: "Enter CAPTCHA"                          
                 EnterKey.enabled: text.length > 2
                 EnterKey.iconSource: "image://theme/icon-m-enter-accept"
                 EnterKey.onClicked: {
@@ -160,7 +138,6 @@ import io.thp.pyotherside 1.4
                     }
                 
            function postthread(response) {
-            console.log("Replying to "+replyTo)
             console.log("posting with captchatoken "+challenge)
             console.log("posting with filepath "+selectedFile)
             console.log("posting with subject "+subject)

--- a/qml/pages/CaptchaPage.qml
+++ b/qml/pages/CaptchaPage.qml
@@ -4,7 +4,7 @@ import "../items"
 import io.thp.pyotherside 1.4
 
 
-        Page {
+    Page {
         id: page
         property string imgdata: ""
         property string bgdata: ""
@@ -45,7 +45,15 @@ import io.thp.pyotherside 1.4
 
         }
 
+    Flickable {
+        id: flick
+        anchors.fill: parent
         
+        PageHeader {
+                id: header
+                title: "Captcha"
+                }
+                
         Item{
             y: screen.height/2 - page.img_height /2
 
@@ -53,7 +61,7 @@ import io.thp.pyotherside 1.4
                 height: page.img_height *2
             Image {
                 id: imgfg
-                anchors.top: parent.top
+                anchors.top: header.bottom
                 width: page.bg_width *2 
                 height: page.img_height *2
                 x: 100 - bgslider.value    
@@ -61,7 +69,7 @@ import io.thp.pyotherside 1.4
             }
             Image {
                 id: imgbg
-                anchors.top: parent.top
+                anchors.top: header.bottom
                 width: page.img_width *2 
                 height: page.img_height *2
                 source: !page.loaded ? page.bgdata : "data:image/png;base64," + page.imgdata  
@@ -75,7 +83,7 @@ import io.thp.pyotherside 1.4
               TextField {
                 id: captchaInput
                 width: parent.width
-                anchors.bottom: imgbg.top
+                anchors.top: imgbg.bottom
                 placeholderText: "Enter CAPTCHA"                          
                 EnterKey.enabled: text.length > 2
                 EnterKey.iconSource: "image://theme/icon-m-enter-accept"
@@ -92,7 +100,7 @@ import io.thp.pyotherside 1.4
         
             Slider {
             id: bgslider
-            anchors.top: imgfg.bottom
+            anchors.top: captchaInput.bottom
             minimumValue: 0
             maximumValue: 200
             stepSize: 2
@@ -105,6 +113,7 @@ import io.thp.pyotherside 1.4
         }
     Component.onCompleted: {
             page.getCaptcha();
+        }
         }
 }
                 Python {

--- a/qml/pages/CaptchaPage.qml
+++ b/qml/pages/CaptchaPage.qml
@@ -91,8 +91,8 @@ import Sailfish.Silica 1.0
                         SearchField {
                 id: searchField
                 width: parent.width
-                anchors.top: parent.bottom
-                placeholderText:  qsTr("Search in all threads")                                              
+                anchors.bottom: imgbg.top
+                                           
                 EnterKey.enabled: text.length > 2
                 EnterKey.iconSource: "image://theme/icon-m-enter-accept"
                 EnterKey.onClicked: {
@@ -101,24 +101,14 @@ import Sailfish.Silica 1.0
                     }
                     
 
-               // onTextChanged: if (!text) _reset()
             }
         
 
-                    /*        Button {
-                    id: captchaSubmit
-                    text: "Submit"
-                                anchors.top: searchField.bottom
-                    enabled: page.response.length
-                    onClicked: {
-                        page.postCaptcha();
-                    }*/
-            
-        //}
+
         
             Slider {
             id: bgslider
-            anchors.bottom: page.bottom
+            anchors.top: imgfg.bottom
             minimumValue: 0
             maximumValue: 200
             stepSize: 2

--- a/qml/pages/CaptchaPage.qml
+++ b/qml/pages/CaptchaPage.qml
@@ -92,7 +92,7 @@ import Sailfish.Silica 1.0
                 id: searchField
                 width: parent.width
                 anchors.bottom: imgbg.top
-                                           
+                placeholderText: "Enter CAPTCHA"                           
                 EnterKey.enabled: text.length > 2
                 EnterKey.iconSource: "image://theme/icon-m-enter-accept"
                 EnterKey.onClicked: {

--- a/qml/pages/CaptchaPage.qml
+++ b/qml/pages/CaptchaPage.qml
@@ -1,0 +1,136 @@
+import QtQuick 2.2
+import Sailfish.Silica 1.0
+
+//ApplicationWindow{
+
+    
+//initialPage: Page {
+        Page {
+    id: page
+        property string imgdata: ""
+        property string bgdata: ""
+        property string challenge
+        property string replyTo
+        property string boardId
+        property string comment
+        property string response
+        property int img_width
+        property int bg_width
+        property int img_height
+        property bool loaded: false
+                       function getCaptcha(){
+            var xhr = new XMLHttpRequest;
+        xhr.open("GET",  "https://sys.4channel.org/captcha?board=" + boardId + "&thread_id=" + replyTo);// + thread_id);
+        xhr.onreadystatechange = function() {
+            if (xhr.readyState === XMLHttpRequest.DONE) {
+                    console.log(boardId, replyTo);
+                var data = JSON.parse(xhr.responseText);
+                    loaded = true;
+                challenge = data.challenge;
+                imgdata  = data.img;
+                img_width = data.img_width;
+                img_height = data.img_height;
+                bgdata = data.bg;
+                bg_width = data.bg_width;
+                    console.log(challenge, img_width, bg_width);                
+            }
+                                
+        }
+            xhr.send();
+
+            console.log("end", page.imgdata,page.loaded);
+        }
+
+        function postCaptcha(text){
+            var xhr = new XMLHttpRequest;
+            var url = "https://sys.4channel.org/" + boardId + "/post";
+            var params = encodeURI("MAX_FILE_SIZE=4194304&mode=regist&resto=" + replyTo + "&name=&email=&com=" + comment + "&t-response=" + text + "&t-challenge=" + challenge); //!|\nContent-Disposition: form-data; name=\"MAX_FILE_SIZE\"\n\n4194304\n!|\nContent-Disposition: form-data; name=\"mode\"\n\nregist\n!|\nContent-Disposition: form-data; name=\"resto\"\n\n4644876\n!|\nContent-Disposition: form-data; name=\"name\"\n\n\n!|\nContent-Disposition: form-data; name=\"email\"\n\n\n!|\nContent-Disposition: form-data; name=\"com\"\n\nTeStA\n!|\nContent-Disposition: form-data; name=\"t-response\"\n\n" + text + "\n!|\nContent-Disposition: form-data; name=\"t-challenge\"\n\n" + challenge + "\n!|--";
+            console.log(params, url);
+        xhr.open("POST",  url, true);
+            xhr.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
+            //multipart/form-data; boundary=!|");
+            xhr.setRequestHeader("Content-length", params.length);
+            xhr.setRequestHeader("Connection", "close");
+            xhr.onreadystatechange = function() {
+            if (xhr.readyState === XMLHttpRequest.DONE) {
+                    console.log(xhr.responseText);
+                }
+            }
+            xhr.send(params);    
+        }
+        
+        Item{
+            y: screen.height/2 - page.img_height /2
+           // x: screen.width/2
+                width: page.img_width *2 
+                height: page.img_height *2
+    Image {
+                id: imgfg
+                anchors.top: parent.top
+                                width: page.bg_width *2 
+                height: page.img_height *2
+                x: 100 - bgslider.value
+                
+                    
+            
+        source: !page.loaded ? page.imgdata : "data:image/png;base64," + page.bgdata  
+            }
+            Image {
+                id: imgbg
+                anchors.top: parent.top
+                                width: page.img_width *2 
+                height: page.img_height *2
+        source: !page.loaded ? page.bgdata : "data:image/png;base64," + page.imgdata  
+            }
+            Rectangle {
+                anchors.left: imgbg.right
+                height: page.img_height *2
+                width: screen.width - page.img_width *2 
+        color: Theme.rgba(Theme.primaryColor, 1)
+            }
+                        SearchField {
+                id: searchField
+                width: parent.width
+                anchors.top: parent.bottom
+                placeholderText:  qsTr("Search in all threads")                                              
+                EnterKey.enabled: text.length > 2
+                EnterKey.iconSource: "image://theme/icon-m-enter-accept"
+                EnterKey.onClicked: {
+                        page.postCaptcha(text);
+                        pageStack.navigateBack();
+                    }
+                    
+
+               // onTextChanged: if (!text) _reset()
+            }
+        
+
+                    /*        Button {
+                    id: captchaSubmit
+                    text: "Submit"
+                                anchors.top: searchField.bottom
+                    enabled: page.response.length
+                    onClicked: {
+                        page.postCaptcha();
+                    }*/
+            
+        //}
+        
+            Slider {
+            id: bgslider
+            anchors.bottom: page.bottom
+            minimumValue: 0
+            maximumValue: 200
+            stepSize: 2
+            enabled: true
+            width: parent.width
+            handleVisible: true
+            label: qsTr("Slide to reveal captcha")
+            
+        
+        }
+    Component.onCompleted: {
+            page.getCaptcha();
+        }
+}
+}

--- a/qml/pages/PostsPage.qml
+++ b/qml/pages/PostsPage.qml
@@ -430,9 +430,13 @@ AbstractPage {
                 replyPostPanel.busy = false
                 replyPostPanel.open = false
                 replyPostPanel.clearFields();
-
+                
+                if (pageStack.depth === 2){
                 infoBanner.alert("Reply sent, reloading..")
                 pyp.getPosts(boardId,postNo)
+                } else {
+                infoBanner.alert("Reply sent.")
+                }
             });
 
             setHandler('reply_failed', function(result) {

--- a/qml/pages/PostsPage.qml
+++ b/qml/pages/PostsPage.qml
@@ -26,6 +26,7 @@ AbstractPage {
     id: postsPage
     objectName: "postsPage"
     property string mode: "post";
+    property string threadId;
     property string singlePost;
     property string poster_id;
     property string country_name;
@@ -111,7 +112,7 @@ AbstractPage {
                 }
 
                 MenuItem {
-                    text: qsTr("Back to " + postNo )
+                    text: qsTr("Back to " + threadId )
                     visible: pageStack.depth !== 2
                     onClicked: {
                         getBackToPost()
@@ -164,7 +165,7 @@ AbstractPage {
                 }
 
                 MenuItem {
-                    text: qsTr("Back to " + postNo )
+                    text: qsTr("Back to " + threadId )
                     visible: pageStack.depth !== 2
                     onClicked: {
                         getBackToPost()


### PR DESCRIPTION
This is just a prototype, pure QML (I'm not sure if we can send pictures this way, there are some remnants of me trying to do a multipart/form-data manually crafted, but yeah, tjc thread from a while ago claims it might be not possible: https://together.jolla.com/question/214496/how-to-send-a-file-using-xmlhttprequest/), no error handling, dockedpost is not hidden after posting and I'm sure plenty more, but with all these caveats it does allow one to post text only replies. Scaled the captcha images by 2 (might be too much for jolla1? images are all between 230ish and 300, so for 540 screens we might need to drop scaling), some kind of dynamic scaling would eventually be nice. Let me know what you think